### PR TITLE
Cleanup and more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+1.0.3
+-----
+* Initial release

--- a/lib/assert/element.js
+++ b/lib/assert/element.js
@@ -9,11 +9,6 @@ function isTextOrRegexp(textOrRegExp) {
   return _.isString(textOrRegExp) || _.isRegExp(textOrRegExp);
 }
 
-exports._getElementWithProperty = function _getElementWithProperty(selector, property) {
-  var element = this._getElement(selector);
-  return [ element, element.get(property) ];
-};
-
 exports._getElement = function _getElement(selector) {
   var elements = this.driver.getElements(selector);
   var count = elements.length;
@@ -76,15 +71,16 @@ exports.elementHasText = function elementHasText(doc, selector, textOrRegExp) {
   assert.hasType('elementHasText(selector, textOrRegExp) - requires selector', String, selector);
   assert.truthy('elementHasText(selector, textOrRegExp) - requires textOrRegExp', isTextOrRegexp(textOrRegExp));
 
-  var result = this._getElementWithProperty(selector, 'text');
+  var element = this._getElement(selector);
+  var actualText = element.get('text');
 
   if (textOrRegExp === '') {
-    assert.equal(textOrRegExp, result[1]);
+    assert.equal(textOrRegExp, actualText);
   } else {
-    assert.include(doc, textOrRegExp, result[1]);
+    assert.include(doc, textOrRegExp, actualText);
   }
 
-  return result[0];
+  return element;
 };
 
 exports.elementLacksText = function elementLacksText(doc, selector, textOrRegExp) {
@@ -99,10 +95,11 @@ exports.elementLacksText = function elementLacksText(doc, selector, textOrRegExp
   assert.hasType('elementLacksText(selector, textOrRegExp) - requires selector', String, selector);
   assert.truthy('elementLacksText(selector, textOrRegExp) - requires textOrRegExp', isTextOrRegexp(textOrRegExp));
 
-  var result = this._getElementWithProperty(selector, 'text');
+  var element = this._getElement(selector);
+  var actualText = element.get('text');
 
-  assert.notInclude(doc, textOrRegExp, result[1]);
-  return result[0];
+  assert.notInclude(doc, textOrRegExp, actualText);
+  return element;
 };
 
 exports.elementHasValue = function elementHasValue(doc, selector, textOrRegExp) {
@@ -117,15 +114,16 @@ exports.elementHasValue = function elementHasValue(doc, selector, textOrRegExp) 
   assert.hasType('elementHasValue(selector, textOrRegExp) - requires selector', String, selector);
   assert.truthy('elementHasValue(selector, textOrRegExp) - requires textOrRegExp', isTextOrRegexp(textOrRegExp));
 
-  var result = this._getElementWithProperty(selector, 'value');
+  var element = this._getElement(selector);
+  var actualValue = element.get('value');
 
   if (textOrRegExp === '') {
-    assert.equal(textOrRegExp, result[1]);
+    assert.equal(textOrRegExp, actualValue);
   } else {
-    assert.include(doc, textOrRegExp, result[1]);
+    assert.include(doc, textOrRegExp, actualValue);
   }
 
-  return result[0];
+  return element;
 };
 
 exports.elementLacksValue = function elementLacksValue(doc, selector, textOrRegExp) {
@@ -140,10 +138,11 @@ exports.elementLacksValue = function elementLacksValue(doc, selector, textOrRegE
   assert.hasType('elementLacksValue(selector, textOrRegExp) - requires selector', String, selector);
   assert.truthy('elementLacksValue(selector, textOrRegExp) - requires textOrRegExp', isTextOrRegexp(textOrRegExp));
 
-  var result = this._getElementWithProperty(selector, 'value');
+  var element = this._getElement(selector);
+  var actualValue = element.get('value');
 
-  assert.notInclude(doc, textOrRegExp, result[1]);
-  return result[0];
+  assert.notInclude(doc, textOrRegExp, actualValue);
+  return element;
 };
 
 exports.elementIsVisible = function elementIsVisible(selector) {

--- a/lib/assert/imgLoaded_client.js
+++ b/lib/assert/imgLoaded_client.js
@@ -1,4 +1,3 @@
-/* jshint browser: true */
 'use strict';
 
 // returns true if the image is loaded and decoded,

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -16,6 +16,9 @@ var builtIns = [
 ];
 
 function Browser(driver, options) {
+  var invocation = 'new Browser(driver, targetUrl, commandUrl)';
+  assert.hasType(invocation + ' - requires (Object) driver', Object, driver);
+
   this.driver = driver;
   this.capabilities = driver.capabilities;
 

--- a/lib/testium-driver-sync.js
+++ b/lib/testium-driver-sync.js
@@ -1,10 +1,23 @@
 'use strict';
 
+var path = require('path');
+
 var WebDriver = require('webdriver-http-sync');
 var debug = require('debug')('testium-driver-sync:browser');
+var _ = require('lodash');
 
 var Browser = require('./browser');
 var Assertions = require('./assert');
+
+function applyMixin(obj, mixin) {
+  debug('Applying mixin to %s', obj.constructor.name, mixin);
+  var mixinFile = path.resolve(process.cwd(), mixin);
+  _.extend(obj, require(mixinFile));
+}
+
+function applyMixins(obj, mixins) {
+  _.each(mixins, _.partial(applyMixin, obj));
+}
 
 function createDriver(testium) {
   var config = testium.config;
@@ -21,26 +34,12 @@ function createDriver(testium) {
   });
   browser.assert = new Assertions(driver, browser);
 
+  applyMixins(browser, config.get('mixins.browser', []));
+  applyMixins(browser.assert, config.get('mixins.assert', []));
+
   // Default to reasonable size.
   // This fixes some phantomjs element size/position reporting.
   browser.setPageSize({ height: 768, width: 1024 });
-
-  var skipPriming = false;
-  var keepCookies = false;
-
-  if (skipPriming) {
-    debug('Skipping priming load');
-  } else {
-    driver.navigateTo(testium.getInitialUrl());
-    debug('Browser was primed');
-  }
-
-  if (keepCookies) {
-    debug('Keeping cookies around');
-  } else {
-    debug('Clearing cookies for clean state');
-    browser.clearCookies();
-  }
 
   return testium;
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "^2.3.3",
     "node-static": "~0.7.7",
     "npub": "^2.2.0",
-    "testium-core": "^1.1.2",
+    "testium-core": "testiumjs/testium-core#jk-driver-factory",
     "testium-example-app": "^1.0.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test": "eslint lib test && mocha",
     "posttest": "npub verify"
   },
+  "files": [
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/testiumjs/testium-driver-sync.git"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "^2.3.3",
     "node-static": "~0.7.7",
     "npub": "^2.2.0",
-    "testium-core": "testiumjs/testium-core#jk-driver-factory",
+    "testium-core": "^1.3.0",
     "testium-example-app": "^1.0.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Sync interface for testium",
   "main": "lib/testium-driver-sync.js",
   "scripts": {
-    "test": "eslint lib test && mocha"
+    "test": "eslint lib test && mocha",
+    "posttest": "npub verify"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "eslint-config-airbnb": "~0.1.0",
     "mocha": "^2.3.3",
     "node-static": "~0.7.7",
+    "npub": "^2.2.0",
     "testium-core": "^1.1.2",
     "testium-example-app": "^1.0.4"
   },

--- a/test/assert/element.test.js
+++ b/test/assert/element.test.js
@@ -5,21 +5,21 @@ import ElementMixin from '../../lib/assert/element';
 
 describe('assert/element', () => {
   describe('#elementHas', () => {
-    var selector = '.box';
-    var text = 'something';
-    var element = extend({
+    const selector = '.box';
+    const text = 'something';
+    const element = extend({
       driver: {
         getElements() {
           return [ { get() { return text; } } ];
-        }
-      }
+        },
+      },
     }, ElementMixin);
 
     describe('Attributes', () => {
-      var attributesObject = {
+      const attributesObject = {
         text: text,
         value: text,
-        id: /something/
+        id: /something/,
       };
 
       it('fails if selector is undefined', () => {
@@ -81,12 +81,12 @@ describe('assert/element', () => {
   });
 
   describe('#elementLacks', () => {
-    var selector = '.box';
-    var text = 'something';
-    var element = extend({
+    const selector = '.box';
+    const text = 'something';
+    const element = extend({
       driver: {
-        getElements() { return [ { get() { return 'else'; } } ]; }
-      }
+        getElements() { return [ { get() { return 'else'; } } ]; },
+      },
     }, ElementMixin);
 
     describe('Text', () => {
@@ -133,15 +133,12 @@ describe('assert/element', () => {
   });
 
   describe('#elementIsVisible', () => {
-    var selector = '.box';
-    var element = extend({
+    const element = extend({
       browser: {
         getElementWithoutError() {
-          return {
-            isVisible() { return true; }
-          };
-        }
-      }
+          return { isVisible() { return true; } };
+        },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -160,13 +157,12 @@ describe('assert/element', () => {
   });
 
   describe('#elementNotVisible', () => {
-    var selector = '.box';
-    var element = extend({
+    const element = extend({
       browser: {
         getElementWithoutError() {
           return { isVisible() { return false; } };
-        }
-      }
+        },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -185,11 +181,10 @@ describe('assert/element', () => {
   });
 
   describe('#elementExists', () => {
-    var selector = '.box';
-    var element = extend({
+    const element = extend({
       browser: {
-        getElementWithoutError() { return {}; }
-      }
+        getElementWithoutError() { return {}; },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -208,11 +203,10 @@ describe('assert/element', () => {
   });
 
   describe('#elementDoesntExist', () => {
-    var selector = '.box';
-    var element = extend({
+    const element = extend({
       browser: {
-        getElementWithoutError() { return null; }
-      }
+        getElementWithoutError() { return null; },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {

--- a/test/assert/element.test.js
+++ b/test/assert/element.test.js
@@ -1,0 +1,233 @@
+import assert from 'assertive';
+import { extend, noop } from 'lodash';
+
+import ElementMixin from '../../lib/assert/element';
+
+describe('assert/element', () => {
+  describe('#elementHas', () => {
+    var selector = '.box';
+    var text = 'something';
+    var element = extend({
+      driver: {
+        getElements() {
+          return [ { get() { return text; } } ];
+        }
+      }
+    }, ElementMixin);
+
+    describe('Attributes', () => {
+      var attributesObject = {
+        text: text,
+        value: text,
+        id: /something/
+      };
+
+      it('fails if selector is undefined', () => {
+        assert.throws(() =>
+          element.elementHasAttributes(undefined, attributesObject));
+      });
+
+      it('fails if selector is not a string', () => {
+        assert.throws(() =>
+          element.elementHasAttributes(999, attributesObject));
+      });
+
+      it('returns the element if all conditions are met', () => {
+        assert.truthy(element.elementHasAttributes(selector, attributesObject));
+      });
+    });
+
+    describe('Text', () => {
+      it('fails if selector is undefined', () => {
+        assert.throws(() =>
+          element.elementHasText(undefined, text));
+      });
+
+      it('fails if selector is not a String', () => {
+        assert.throws(() =>
+          element.elementHasText(999, text));
+      });
+
+      it('fails if text is undefined', () => {
+        assert.throws(() =>
+          element.elementHasText(selector, undefined));
+      });
+
+      it('returns the element if all conditions are met', () => {
+        assert.truthy(element.elementHasText(selector, text));
+      });
+    });
+
+    describe('Value', () => {
+      it('fails if selector is undefined', () => {
+        assert.throws(() =>
+          element.elementHasValue(undefined, text));
+      });
+
+      it('fails if selector is not a String', () => {
+        assert.throws(() =>
+          element.elementHasValue(999, text));
+      });
+
+      it('fails if text is undefined', () => {
+        assert.throws(() =>
+          element.elementHasValue(selector, undefined));
+      });
+
+      it('returns the element if all conditions are met', () => {
+        assert.truthy(element.elementHasValue(selector, text));
+      });
+    });
+  });
+
+  describe('#elementLacks', () => {
+    var selector = '.box';
+    var text = 'something';
+    var element = extend({
+      driver: {
+        getElements() { return [ { get() { return 'else'; } } ]; }
+      }
+    }, ElementMixin);
+
+    describe('Text', () => {
+      it('fails if selector is undefined', () => {
+        assert.throws(() =>
+          element.elementLacksText(undefined, text));
+      });
+
+      it('fails if selector is not a String', () => {
+        assert.throws(() =>
+          element.elementLacksText(999, text));
+      });
+
+      it('fails if text is undefined', () => {
+        assert.throws(() =>
+          element.elementLacksText(selector, undefined));
+      });
+
+      it('returns the element if all conditions are met', () => {
+        assert.truthy(element.elementLacksText(selector, text));
+      });
+    });
+
+    describe('Value', () => {
+      it('fails if selector is undefined', () => {
+        assert.throws(() =>
+          element.elementLacksValue(undefined, text));
+      });
+
+      it('fails if selector is not a String', () => {
+        assert.throws(() =>
+          element.elementLacksValue(999, text));
+      });
+
+      it('fails if text is undefined', () => {
+        assert.throws(() =>
+          element.elementLacksValue(selector, undefined));
+      });
+
+      it('returns the element if all conditions are met', () => {
+        assert.truthy(element.elementLacksValue(selector, text));
+      });
+    });
+  });
+
+  describe('#elementIsVisible', () => {
+    var selector = '.box';
+    var element = extend({
+      browser: {
+        getElementWithoutError() {
+          return {
+            isVisible() { return true; }
+          };
+        }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() =>
+        element.elementIsVisible(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() =>
+        element.elementIsVisible(noop));
+    });
+
+    it('returns the element if all conditions are met', () => {
+      assert.truthy(element.elementIsVisible('.box'));
+    });
+  });
+
+  describe('#elementNotVisible', () => {
+    var selector = '.box';
+    var element = extend({
+      browser: {
+        getElementWithoutError() {
+          return { isVisible() { return false; } };
+        }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() =>
+        element.elementNotVisible(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() =>
+        element.elementNotVisible(noop));
+    });
+
+    it('returns the element if all conditions are met', () => {
+      assert.truthy(element.elementNotVisible('.box'));
+    });
+  });
+
+  describe('#elementExists', () => {
+    var selector = '.box';
+    var element = extend({
+      browser: {
+        getElementWithoutError() { return {}; }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() =>
+        element.elementExists(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() =>
+        element.elementExists(noop));
+    });
+
+    it('returns the element if all conditions are met', () => {
+      assert.truthy(element.elementExists('.box'));
+    });
+  });
+
+  describe('#elementDoesntExist', () => {
+    var selector = '.box';
+    var element = extend({
+      browser: {
+        getElementWithoutError() { return null; }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() =>
+        element.elementDoesntExist(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() =>
+        element.elementDoesntExist(noop));
+    });
+
+    it('succeeds if all conditions are met', () => {
+      element.elementDoesntExist('.box');
+    });
+  });
+});
+

--- a/test/assert/imgLoaded.test.js
+++ b/test/assert/imgLoaded.test.js
@@ -1,0 +1,24 @@
+import assert from 'assertive';
+import { extend, noop } from 'lodash';
+
+import ImgLoadedMixin from '../../lib/assert/imgLoaded';
+
+describe('imgLoaded', () => {
+  var context = extend({
+    browser: {
+      evaluate() { return true; }
+    }
+  }, ImgLoadedMixin);
+
+  it('fails if selector is undefined', () => {
+    assert.throws(() => context.imgLoaded(undefined));
+  });
+
+  it('fails if selector is not a String', () => {
+    assert.throws(() => context.imgLoaded(noop));
+  });
+
+  it('succeeds if all conditions are met', () => {
+    context.imgLoaded('.thumb');
+  });
+});

--- a/test/assert/imgLoaded.test.js
+++ b/test/assert/imgLoaded.test.js
@@ -4,10 +4,10 @@ import { extend, noop } from 'lodash';
 import ImgLoadedMixin from '../../lib/assert/imgLoaded';
 
 describe('imgLoaded', () => {
-  var context = extend({
+  const context = extend({
     browser: {
-      evaluate() { return true; }
-    }
+      evaluate() { return true; },
+    },
   }, ImgLoadedMixin);
 
   it('fails if selector is undefined', () => {

--- a/test/assert/navigation.test.js
+++ b/test/assert/navigation.test.js
@@ -4,10 +4,10 @@ import { extend } from 'lodash';
 import NavigationMixin from '../../lib/assert/navigation';
 
 describe('assert.navigations', () => {
-  var context = extend({
+  const context = extend({
     browser: {
-      getStatusCode() { return 200; }
-    }
+      getStatusCode() { return 200; },
+    },
   }, NavigationMixin);
 
   it('fails if expectedStatus is undefined', () => {

--- a/test/assert/navigation.test.js
+++ b/test/assert/navigation.test.js
@@ -1,0 +1,24 @@
+import assert from 'assertive';
+import { extend } from 'lodash';
+
+import NavigationMixin from '../../lib/assert/navigation';
+
+describe('assert.navigations', () => {
+  var context = extend({
+    browser: {
+      getStatusCode() { return 200; }
+    }
+  }, NavigationMixin);
+
+  it('fails if expectedStatus is undefined', () => {
+    assert.throws(() => context.httpStatus(undefined));
+  });
+
+  it('fails if expectedStatus is not a number', () => {
+    assert.throws(() => context.httpStatus('200'));
+  });
+
+  it('succeeds if expectedStatus is a number', () => {
+    context.httpStatus(200);
+  });
+});

--- a/test/browser/cookie.test.js
+++ b/test/browser/cookie.test.js
@@ -1,0 +1,70 @@
+import assert from 'assertive';
+import { extend, noop } from 'lodash';
+
+import CookieMixin from '../../lib/browser/cookie';
+
+describe('cookie', () => {
+  describe('#setCookie', () => {
+    var cookie = extend({
+      driver: {
+        setCookie() {}
+      }
+    }, CookieMixin);
+
+    it('fails if cookie is undefined', () => {
+      assert.throws(() => cookie.setCookie(undefined));
+    });
+
+    it('fails if cookie does not contain name', () => {
+      assert.throws(() => cookie.setCookie({ value: 'chicago' }));
+    });
+
+    it('fails if cookie does not contain value', () => {
+      assert.throws(() => cookie.setCookie({ name: 'division' }));
+    });
+  });
+
+  describe('#getCookie', () => {
+    var cookie = extend({
+      driver: {
+        getCookies() { return []; }
+      }
+    }, CookieMixin);
+
+    it('fails if name is undefined', () => {
+      assert.throws(() => cookie.getCookie(undefined));
+    });
+
+    it('fails if name is not a String', () => {
+      assert.throws(() => cookie.getCookie(noop));
+    });
+
+    it('succeeds if name is a String', () => {
+      cookie.getCookie('division');
+    });
+  });
+
+  describe('#getHeader', () => {
+    var testiumCookie = {
+      name: '_testium_',
+      value: 'eyJoZWFkZXJzIjp7InNlcnZlciI6Im5vZGUtc3RhdGljLzAuNy4wIiwiY2FjaGUtY29udHJvbCI6Im1heC1hZ2U9MzYwMCIsImV0YWciOiJcIjE1ODI5ODQtMjUyNi0xMzkxNTI5MDM2MDAwXCIiLCJkYXRlIjoiTW9uLCAwMyBNYXIgMjAxNCAwNDo0MDoxNCBHTVQiLCJsYXN0LW1vZGlmaWVkIjoiVHVlLCAwNCBGZWIgMjAxNCAxNTo1MDozNiBHTVQiLCJjb250ZW50LXR5cGUiOiJ0ZXh0L2h0bWwiLCJjb250ZW50LWxlbmd0aCI6IjI1MjYiLCJjb25uZWN0aW9uIjoia2VlcC1hbGl2ZSIsIkNhY2hlLUNvbnRyb2wiOiJuby1zdG9yZSJ9LCJzdGF0dXNDb2RlIjoyMDB9',
+    };
+    var cookie = extend({
+      driver: {
+        getCookies() { return [ testiumCookie ]; }
+      }
+    }, CookieMixin);
+
+    it('fails if name is undefined', () => {
+      assert.throws(() => cookie.getHeader(undefined));
+    });
+
+    it('fails if name is not a String', () => {
+      assert.throws(() => cookie.getHeader(noop));
+    });
+
+    it('succeeds if name is a String', () => {
+      cookie.getHeader('user-agent');
+    });
+  });
+});

--- a/test/browser/cookie.test.js
+++ b/test/browser/cookie.test.js
@@ -5,10 +5,10 @@ import CookieMixin from '../../lib/browser/cookie';
 
 describe('cookie', () => {
   describe('#setCookie', () => {
-    var cookie = extend({
+    const cookie = extend({
       driver: {
-        setCookie() {}
-      }
+        setCookie() {},
+      },
     }, CookieMixin);
 
     it('fails if cookie is undefined', () => {
@@ -25,10 +25,10 @@ describe('cookie', () => {
   });
 
   describe('#getCookie', () => {
-    var cookie = extend({
+    const cookie = extend({
       driver: {
-        getCookies() { return []; }
-      }
+        getCookies() { return []; },
+      },
     }, CookieMixin);
 
     it('fails if name is undefined', () => {
@@ -45,14 +45,14 @@ describe('cookie', () => {
   });
 
   describe('#getHeader', () => {
-    var testiumCookie = {
+    const testiumCookie = {
       name: '_testium_',
       value: 'eyJoZWFkZXJzIjp7InNlcnZlciI6Im5vZGUtc3RhdGljLzAuNy4wIiwiY2FjaGUtY29udHJvbCI6Im1heC1hZ2U9MzYwMCIsImV0YWciOiJcIjE1ODI5ODQtMjUyNi0xMzkxNTI5MDM2MDAwXCIiLCJkYXRlIjoiTW9uLCAwMyBNYXIgMjAxNCAwNDo0MDoxNCBHTVQiLCJsYXN0LW1vZGlmaWVkIjoiVHVlLCAwNCBGZWIgMjAxNCAxNTo1MDozNiBHTVQiLCJjb250ZW50LXR5cGUiOiJ0ZXh0L2h0bWwiLCJjb250ZW50LWxlbmd0aCI6IjI1MjYiLCJjb25uZWN0aW9uIjoia2VlcC1hbGl2ZSIsIkNhY2hlLUNvbnRyb2wiOiJuby1zdG9yZSJ9LCJzdGF0dXNDb2RlIjoyMDB9',
     };
-    var cookie = extend({
+    const cookie = extend({
       driver: {
-        getCookies() { return [ testiumCookie ]; }
-      }
+        getCookies() { return [ testiumCookie ]; },
+      },
     }, CookieMixin);
 
     it('fails if name is undefined', () => {

--- a/test/browser/element.test.js
+++ b/test/browser/element.test.js
@@ -1,0 +1,92 @@
+import assert from 'assertive';
+import { extend, noop } from 'lodash';
+
+import ElementMixin from '../../lib/browser/element';
+
+describe('element', () => {
+  describe('#getElement', () => {
+    var element = extend({
+      driver: {
+        getElement() {}
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => element.getElement(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => element.getElement(noop));
+    });
+
+    it('succeeds if selector is a String', () => {
+      element.getElement('.box');
+    });
+  });
+
+  describe('#waitForElementVisible', () => {
+    var element = extend({
+      driver: {
+        setElementTimeout() {},
+        getElement() {
+          return { isVisible() { return true; } };
+        }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => element.waitForElementVisible(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => element.waitForElementVisible(noop));
+    });
+
+    it('succeeds if selector is a String', () => {
+      element.waitForElementVisible('.box');
+    });
+  });
+
+  describe('#waitForElementNotVisible', () => {
+    var element = extend({
+      driver: {
+        setElementTimeout() {},
+        getElement() { return { isVisible() { return false; } } }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => element.waitForElementNotVisible(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => element.waitForElementNotVisible(noop));
+    });
+
+    it('succeeds if selector is a String', () => {
+      element.waitForElementNotVisible('.box');
+    });
+  });
+
+  describe('#click', () => {
+    var element = extend({
+      driver: {
+        getElement() {
+          return { click() {} };
+        }
+      }
+    }, ElementMixin);
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => element.click(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => element.click(noop));
+    });
+
+    it('succeeds if selector is a String', () => {
+      element.click('.box');
+    });
+  });
+});

--- a/test/browser/element.test.js
+++ b/test/browser/element.test.js
@@ -5,10 +5,10 @@ import ElementMixin from '../../lib/browser/element';
 
 describe('element', () => {
   describe('#getElement', () => {
-    var element = extend({
+    const element = extend({
       driver: {
-        getElement() {}
-      }
+        getElement() {},
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -25,13 +25,13 @@ describe('element', () => {
   });
 
   describe('#waitForElementVisible', () => {
-    var element = extend({
+    const element = extend({
       driver: {
         setElementTimeout() {},
         getElement() {
           return { isVisible() { return true; } };
-        }
-      }
+        },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -48,11 +48,11 @@ describe('element', () => {
   });
 
   describe('#waitForElementNotVisible', () => {
-    var element = extend({
+    const element = extend({
       driver: {
         setElementTimeout() {},
-        getElement() { return { isVisible() { return false; } } }
-      }
+        getElement() { return { isVisible() { return false; } }; },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {
@@ -69,12 +69,12 @@ describe('element', () => {
   });
 
   describe('#click', () => {
-    var element = extend({
+    const element = extend({
       driver: {
         getElement() {
           return { click() {} };
-        }
-      }
+        },
+      },
     }, ElementMixin);
 
     it('fails if selector is undefined', () => {

--- a/test/browser/index.test.js
+++ b/test/browser/index.test.js
@@ -13,9 +13,9 @@ class FakeWebDriver {
 
 describe('API', () => {
   describe('construction', () => {
-    var driver = new FakeWebDriver();
-    var targetUrl = 'http://127.0.0.1:1000';
-    var commandUrl = 'http://127.0.0.1:2000';
+    const driver = new FakeWebDriver();
+    const targetUrl = 'http://127.0.0.1:1000';
+    const commandUrl = 'http://127.0.0.1:2000';
 
     it('fails if driver is undefined', () => {
       assert.throws(() =>
@@ -27,28 +27,25 @@ describe('API', () => {
         new Browser('Not a driver', {targetUrl, commandUrl}));
     });
 
-    it('succeeds if all conditions are met', () => {
-      new Browser(driver);
-    });
+    it('succeeds if all conditions are met', () =>
+      new Browser(driver));
   });
 
   describe('#evaluate', () => {
     it('fails if clientFunction is undefined', () => {
-      var err = assert.throws(() =>
+      const err = assert.throws(() =>
         Browser.prototype.evaluate.call({}, undefined));
       assert.include('requires (Function|String) clientFunction', err.message);
     });
 
     it('fails if clientFunction is not a Function or String', () => {
-      var err = assert.throws(() =>
+      const err = assert.throws(() =>
         Browser.prototype.evaluate.call({}, 999));
       assert.include('requires (Function|String) clientFunction', err.message);
     });
 
     it('succeeds if all conditions are met', done => {
-      var dummyContext = {
-        driver: { evaluate() { done(); } }
-      };
+      const dummyContext = { driver: { evaluate() { done(); } } };
       Browser.prototype.evaluate.call(dummyContext, noop);
     });
   });

--- a/test/browser/index.test.js
+++ b/test/browser/index.test.js
@@ -1,0 +1,55 @@
+import assert from 'assertive';
+import { noop } from 'lodash';
+
+import Browser from '../../lib/browser';
+
+class FakeWebDriver {
+  navigateTo() {}
+  getUrl() {}
+  getCurrentWindowHandle() {}
+  clearCookies() {}
+  setPageSize() {}
+}
+
+describe('API', () => {
+  describe('construction', () => {
+    var driver = new FakeWebDriver();
+    var targetUrl = 'http://127.0.0.1:1000';
+    var commandUrl = 'http://127.0.0.1:2000';
+
+    it('fails if driver is undefined', () => {
+      assert.throws(() =>
+        new Browser(undefined, {targetUrl, commandUrl}));
+    });
+
+    it('fails if driver is not an object', () => {
+      assert.throws(() =>
+        new Browser('Not a driver', {targetUrl, commandUrl}));
+    });
+
+    it('succeeds if all conditions are met', () => {
+      new Browser(driver);
+    });
+  });
+
+  describe('#evaluate', () => {
+    it('fails if clientFunction is undefined', () => {
+      var err = assert.throws(() =>
+        Browser.prototype.evaluate.call({}, undefined));
+      assert.include('requires (Function|String) clientFunction', err.message);
+    });
+
+    it('fails if clientFunction is not a Function or String', () => {
+      var err = assert.throws(() =>
+        Browser.prototype.evaluate.call({}, 999));
+      assert.include('requires (Function|String) clientFunction', err.message);
+    });
+
+    it('succeeds if all conditions are met', done => {
+      var dummyContext = {
+        driver: { evaluate() { done(); } }
+      };
+      Browser.prototype.evaluate.call(dummyContext, noop);
+    });
+  });
+});

--- a/test/browser/input.test.js
+++ b/test/browser/input.test.js
@@ -1,0 +1,76 @@
+import assert from 'assertive';
+import { extend, noop } from 'lodash';
+
+import InputMixin from '../../lib/browser/input';
+
+describe('input api', () => {
+  describe('#type', () => {
+    var element = { type() {} };
+    var input = extend({
+      getExistingElement() { return element; }
+    }, InputMixin);
+    var selector = '.box';
+    var keys = 'puppies';
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => input.type(undefined, keys));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => input.type(noop, keys));
+    });
+
+    it('fails if keys is not defined', () => {
+      assert.throws(() => input.type(selector));
+    });
+
+    it('succeeds if all conditions are met', () => {
+      input.type(selector, keys);
+    });
+  });
+
+  describe('#clear', () => {
+    var element = { clear() {} };
+    var input = extend({
+      getExistingElement() { return element; }
+    }, InputMixin);
+    var selector = '.box';
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => input.clear(undefined));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => input.clear(noop));
+    });
+
+    it('succeeds if all conditions are met', () => {
+      input.clear(selector);
+    });
+  });
+
+  describe('#clearAndType', () => {
+    var element = { clear() {}, type() {} };
+    var input = extend({
+      getExistingElement() { return element; }
+    }, InputMixin);
+    var selector = '.box';
+    var keys = 'puppies';
+
+    it('fails if selector is undefined', () => {
+      assert.throws(() => input.clearAndType(undefined, keys));
+    });
+
+    it('fails if selector is not a String', () => {
+      assert.throws(() => input.clearAndType(noop, keys));
+    });
+
+    it('fails if keys is not defined', () => {
+      assert.throws(() => input.clearAndType(selector));
+    });
+
+    it('succeeds if all conditions are met', () => {
+      input.clearAndType(selector, keys);
+    });
+  });
+});

--- a/test/browser/input.test.js
+++ b/test/browser/input.test.js
@@ -5,12 +5,12 @@ import InputMixin from '../../lib/browser/input';
 
 describe('input api', () => {
   describe('#type', () => {
-    var element = { type() {} };
-    var input = extend({
-      getExistingElement() { return element; }
+    const element = { type() {} };
+    const input = extend({
+      getExistingElement() { return element; },
     }, InputMixin);
-    var selector = '.box';
-    var keys = 'puppies';
+    const selector = '.box';
+    const keys = 'puppies';
 
     it('fails if selector is undefined', () => {
       assert.throws(() => input.type(undefined, keys));
@@ -30,11 +30,11 @@ describe('input api', () => {
   });
 
   describe('#clear', () => {
-    var element = { clear() {} };
-    var input = extend({
-      getExistingElement() { return element; }
+    const element = { clear() {} };
+    const input = extend({
+      getExistingElement() { return element; },
     }, InputMixin);
-    var selector = '.box';
+    const selector = '.box';
 
     it('fails if selector is undefined', () => {
       assert.throws(() => input.clear(undefined));
@@ -50,12 +50,12 @@ describe('input api', () => {
   });
 
   describe('#clearAndType', () => {
-    var element = { clear() {}, type() {} };
-    var input = extend({
-      getExistingElement() { return element; }
+    const element = { clear() {}, type() {} };
+    const input = extend({
+      getExistingElement() { return element; },
     }, InputMixin);
-    var selector = '.box';
-    var keys = 'puppies';
+    const selector = '.box';
+    const keys = 'puppies';
 
     it('fails if selector is undefined', () => {
       assert.throws(() => input.clearAndType(undefined, keys));

--- a/test/integration/header.test.js
+++ b/test/integration/header.test.js
@@ -5,7 +5,7 @@ describe('header', () => {
   let browser;
   before(async () => (browser = await getBrowser()));
 
-  describe('can be retireved', () => {
+  describe('can be retrieved', () => {
     before(() => {
       browser.navigateTo('/');
       browser.assert.httpStatus(200);

--- a/test/mini-testium-mocha.js
+++ b/test/mini-testium-mocha.js
@@ -1,18 +1,14 @@
 // This is a minimal version of `testium-mocha`.
 // We're trying to avoid cyclic dependencies.
-import initTestium from 'testium-core';
-import {once} from 'lodash';
+import TestiumCore from 'testium-core';
 
 import createDriver from '../';
 
 let browser = null;
 
-async function createBrowser() {
-  const testium = await initTestium().then(createDriver);
-  browser = testium.browser;
+export async function getBrowser() {
+  browser = await TestiumCore.getBrowser({ driver: createDriver });
   return browser;
 }
 
 after(() => browser && browser.close());
-
-export const getBrowser = once(createBrowser);


### PR DESCRIPTION
Follow-up to https://github.com/testiumjs/testium-driver-sync/pull/1:

* The unit tests for `browser` and `assert` are not ported to `testium-driver-sync` yet
* Inline `_getElementWithProperty` usages
* Remove traces of `jshint`
* `s/retireved/retrieved/`
* Add `npub`
* Add support for mix-ins

~~Depends on https://github.com/testiumjs/testium-core/pull/10.~~

Part of https://github.com/groupon/testium/pull/171