### PR TITLE
Fix tests when running as `mocha | cat`

### DIFF
--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -1,6 +1,10 @@
 import {getBrowser} from '../mini-testium-mocha';
 import assert from 'assertive';
 
+function stripColors(message) {
+  return message.replace(/\u001b\[[^m]*m/g, '');
+}
+
 describe('element', () => {
   let browser;
   before(async () => (browser = await getBrowser()));
@@ -35,14 +39,14 @@ describe('element', () => {
   describe('elementIsVisible', () => {
     it('fails if element does not exist', () => {
       const error = assert.throws(() => browser.assert.elementIsVisible('.non-existing'));
-      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy';
+      assert.equal(expectedError, stripColors(error.message));
     });
 
     it('fails if element exists, but is not visible', () => {
       const error = assert.throws(() => browser.assert.elementIsVisible('#hidden_thing'));
-      const expectedError = 'Assertion failed: Element should be visible for selector: #hidden_thing\n\u001b[39;49;00mExpected \u001b[31mfalse\u001b[39m to be truthy';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element should be visible for selector: #hidden_thing\nExpected false to be truthy';
+      assert.equal(expectedError, stripColors(error.message));
     });
 
     it('succeeds if element exists and is visible', () => {
@@ -53,14 +57,14 @@ describe('element', () => {
   describe('elementNotVisible', () => {
     it('fails if element does not exist', () => {
       const error = assert.throws(() => browser.assert.elementNotVisible('.non-existing'));
-      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy';
+      assert.equal(expectedError, stripColors(error.message));
     });
 
     it('fails if element exists, but is visible', () => {
       const error = assert.throws(() => browser.assert.elementNotVisible('h1'));
-      const expectedError = 'Assertion failed: Element should not be visible for selector: h1\n\u001b[39;49;00mExpected \u001b[31mtrue\u001b[39m to be falsey';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element should not be visible for selector: h1\nExpected true to be falsey';
+      assert.equal(expectedError, stripColors(error.message));
     });
 
     it('succeeds if element exists and is not visible', () => {
@@ -71,8 +75,8 @@ describe('element', () => {
   describe('elementExists', () => {
     it('fails if element does not exist', () => {
       const error = assert.throws(() => browser.assert.elementExists('.non-existing'));
-      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\n\u001b[39;49;00mExpected \u001b[31mnull\u001b[39m to be truthy';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element not found for selector: .non-existing\nExpected null to be truthy';
+      assert.equal(expectedError, stripColors(error.message));
     });
 
     it('succeeds if element exists', () => {
@@ -87,8 +91,8 @@ describe('element', () => {
 
     it('fails if element exists', () => {
       const error = assert.throws(() => browser.assert.elementDoesntExist('h1'));
-      const expectedError = 'Assertion failed: Element found for selector: h1\n\u001b[39;49;00mExpected \u001b[31mElement\u001b[39m to be falsey';
-      assert.equal(expectedError, error.message);
+      const expectedError = 'Assertion failed: Element found for selector: h1\nExpected Element to be falsey';
+      assert.equal(expectedError, stripColors(error.message));
     });
   });
 
@@ -102,8 +106,8 @@ describe('element', () => {
       const error = assert.throws(() =>
         browser.assert.elementHasText('.only', 'the wrong text'));
 
-      const expected = 'Assertion failed: elementHasText: .only\n\u001b[39;49;00minclude expected needle to be found in haystack\n- needle: \"the wrong text\"\nhaystack: \"only one here\"';
-      assert.equal(expected, error.message);
+      const expected = 'Assertion failed: elementHasText: .only\ninclude expected needle to be found in haystack\n- needle: \"the wrong text\"\nhaystack: \"only one here\"';
+      assert.equal(expected, stripColors(error.message));
     });
 
     it('finds no elements', () => {
@@ -135,8 +139,8 @@ describe('element', () => {
       const error = assert.throws(() =>
         browser.assert.elementLacksText('.only', 'only'));
 
-      const expected = 'Assertion failed: elementLacksText: .only\n\u001b[39;49;00mnotInclude expected needle not to be found in haystack\n- needle: \"only\"\nhaystack: \"only one here\"';
-      assert.equal(expected, error.message);
+      const expected = 'Assertion failed: elementLacksText: .only\nnotInclude expected needle not to be found in haystack\n- needle: \"only\"\nhaystack: \"only one here\"';
+      assert.equal(expected, stripColors(error.message));
     });
   });
 
@@ -161,8 +165,8 @@ describe('element', () => {
       const error = assert.throws(() =>
         browser.assert.elementLacksValue('#text-input', 'initialvalue'));
 
-      const expected = 'Assertion failed: elementLacksValue: #text-input\n\u001b[39;49;00mnotInclude expected needle not to be found in haystack\n- needle: \"initialvalue\"\nhaystack: \"initialvalue\"';
-      assert.equal(expected, error.message);
+      const expected = 'Assertion failed: elementLacksValue: #text-input\nnotInclude expected needle not to be found in haystack\n- needle: \"initialvalue\"\nhaystack: \"initialvalue\"';
+      assert.equal(expected, stripColors(error.message));
     });
   });
 


### PR DESCRIPTION
Turns out `npub` runs the test suite differently than CI (e.g. TTY/colors) which causes some of our tests to fail. This change makes the tests pass with and without colors.