### PR TITLE
Fix tests to fail as they should

### DIFF
--- a/lib/browser/cookie.js
+++ b/lib/browser/cookie.js
@@ -8,6 +8,7 @@ var getTestiumCookie = require('testium-cookie').getTestiumCookie;
 exports._forwarded = [
   // TODO: Port validateCookie to webdriver-http-sync
   'setCookie',
+  'clearCookie',
   'clearCookies',
 ];
 
@@ -25,14 +26,6 @@ exports.getCookie = function getCookie(name) {
 
 exports.getCookies = function getCookies() {
   return _.reject(this.driver.getCookies(), { name: '_testium_' });
-};
-
-exports.clearCookie = function clearCookie(name) {
-  return this.setCookie({
-    name: name,
-    value: 'dummy', // setCookie doesn't allow null values
-    expiry: 0,
-  });
 };
 
 // BEGIN _testium_ cookie magic

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -7,12 +7,6 @@ var _ = require('lodash');
 
 var STALE_MESSAGE = /stale element reference/;
 
-var NOT_FOUND_MESSAGE = new RegExp([
-  'Unable to locate element', // firefox message
-  'Unable to find element', // phantomjs message
-  'no such element', // chrome message
-].join('|'));
-
 function visiblePredicate(shouldBeVisible, element) {
   return element && element.isVisible() === shouldBeVisible;
 }
@@ -52,17 +46,7 @@ exports._forwarded = [
 exports.getElementWithoutError = function getElementWithoutError(selector) {
   // TODO: part typeof selector === string check to webdriver-http-sync
   assert.hasType('`selector` as to be a String', String, selector);
-  try {
-    return this.driver.getElement(selector);
-  } catch (exception) {
-    var message = exception.toString();
-
-    if (NOT_FOUND_MESSAGE.test(message)) {
-      return null;
-    }
-
-    throw exception;
-  }
+  return this.driver.getElement(selector);
 };
 
 exports.getElement = exports.getElementWithoutError;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-static": "~0.7.7",
     "npub": "^2.2.0",
     "testium-core": "^1.3.0",
-    "testium-example-app": "testiumjs/testium-example-app#jk-fix-frames"
+    "testium-example-app": "^2.0.0"
   },
   "dependencies": {
     "assertive": "^2.0.2",
@@ -43,7 +43,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "testium-cookie": "^1.0.0",
-    "webdriver-http-sync": "groupon/webdriver-http-sync#jk-fail-more-often"
+    "webdriver-http-sync": "^2.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-static": "~0.7.7",
     "npub": "^2.2.0",
     "testium-core": "^1.3.0",
-    "testium-example-app": "^1.0.4"
+    "testium-example-app": "testiumjs/testium-example-app#jk-fix-frames"
   },
   "dependencies": {
     "assertive": "^2.0.2",
@@ -43,7 +43,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "testium-cookie": "^1.0.0",
-    "webdriver-http-sync": "^1.2.1"
+    "webdriver-http-sync": "groupon/webdriver-http-sync#jk-fail-more-often"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/test/integration/window.test.js
+++ b/test/integration/window.test.js
@@ -21,8 +21,21 @@ describe('window api', () => {
     });
 
     it('fails with invalid frame', () => {
-      assert.throws(() =>
+      const error = assert.throws(() =>
         browser.switchToFrame('invalid-frame'));
+
+      switch (browser.capabilities.browserName) {
+      case 'phantomjs':
+        assert.equal('Unable to switch to frame', error.message);
+        break;
+
+      case 'chrome':
+        assert.include('no such frame', error.message);
+        break;
+
+      default:
+        // Other browsers might have other error messages.
+      }
     });
 
     it('can be found when nested', () => {

--- a/test/integration/window.test.js
+++ b/test/integration/window.test.js
@@ -20,8 +20,16 @@ describe('window api', () => {
       assert.equal(null, primaryContent);
     });
 
+    it('fails with invalid frame', () => {
+      assert.throws(() =>
+        browser.switchToFrame('invalid-frame'));
+    });
+
     it('can be found when nested', () => {
       browser.switchToFrame('cool-frame');
+      const outsideElement = browser.getElement('#nested-frame-div');
+      assert.equal(null, outsideElement);
+
       browser.switchToFrame('nested-frame');
       const element = browser.getElement('#nested-frame-div');
       assert.truthy('nested frame content', element);


### PR DESCRIPTION
Nice side effect of trying to implement the same API in two different ways: It brings up tests that shouldn't be passing as they are.

Background: `<frame>` tags don't actually work for `switchToFrame` and it's possible to get to the elements inside them without switching into the frames.

Depends on groupon/webdriver-http-sync#35 and testiumjs/testium-example-app#3.