### PR TITLE
Deprecate: getElement returns null

### DIFF
--- a/lib/assert/element.js
+++ b/lib/assert/element.js
@@ -147,7 +147,7 @@ exports.elementLacksValue = function elementLacksValue(doc, selector, textOrRegE
 
 exports.elementIsVisible = function elementIsVisible(selector) {
   assert.hasType('elementIsVisible(selector) - requires (String) selector', String, selector);
-  var element = this.browser.getElementWithoutError(selector);
+  var element = this.browser.getElementOrNull(selector);
   assert.truthy('Element not found for selector: ' + selector, element);
   assert.truthy('Element should be visible for selector: ' + selector, element.isVisible());
   return element;
@@ -155,7 +155,7 @@ exports.elementIsVisible = function elementIsVisible(selector) {
 
 exports.elementNotVisible = function elementNotVisible(selector) {
   assert.hasType('elementNotVisible(selector) - requires (String) selector', String, selector);
-  var element = this.browser.getElementWithoutError(selector);
+  var element = this.browser.getElementOrNull(selector);
   assert.truthy('Element not found for selector: ' + selector, element);
   assert.falsey('Element should not be visible for selector: ' + selector, element.isVisible());
   return element;
@@ -163,13 +163,13 @@ exports.elementNotVisible = function elementNotVisible(selector) {
 
 exports.elementExists = function elementExists(selector) {
   assert.hasType('elementExists(selector) - requires (String) selector', String, selector);
-  var element = this.browser.getElementWithoutError(selector);
+  var element = this.browser.getElementOrNull(selector);
   assert.truthy('Element not found for selector: ' + selector, element);
   return element;
 };
 
 exports.elementDoesntExist = function elementDoesntExist(selector) {
   assert.hasType('elementDoesntExist(selector) - requires (String) selector', String, selector);
-  var element = this.browser.getElementWithoutError(selector);
+  var element = this.browser.getElementOrNull(selector);
   assert.falsey('Element found for selector: ' + selector, element);
 };

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -49,7 +49,7 @@ exports._forwarded = [
   'getElements',
 ];
 
-exports.getElementWithoutError = function getElementWithoutError(selector) {
+exports.getElementOrNull = function getElementOrNull(selector) {
   // TODO: part typeof selector === string check to webdriver-http-sync
   assert.hasType('`selector` as to be a String', String, selector);
   try {
@@ -65,10 +65,23 @@ exports.getElementWithoutError = function getElementWithoutError(selector) {
   }
 };
 
-exports.getElement = exports.getElementWithoutError;
+var warnAboutFutureException = util.deprecate(_.noop, [
+  'WARNING:',
+  'getElement was used with a selector that doesn\'t match an element.',
+  'Use getElementOrNull if that\'s expected.',
+  'In future versions of testium-driver-sync, getElement will throw.',
+].join('\n'));
+
+exports.getElement = function getElement(selector) {
+  var element = this.getElementOrNull(selector);
+  if (element === null) {
+    warnAboutFutureException();
+  }
+  return element;
+};
 
 exports.getExistingElement = function getExistingElement(selector) {
-  var element = this.getElement(selector);
+  var element = this.getElementOrNull(selector);
   assert.truthy('Element not found at selector: ' + selector, element);
   return element;
 };
@@ -99,7 +112,7 @@ function tryFindElement(self, selector, predicate, untilTime) {
   var element;
 
   while (Date.now() < untilTime) {
-    element = self.getElementWithoutError(selector);
+    element = self.getElementOrNull(selector);
 
     try {
       if (predicate(element)) {

--- a/test/assert/element.test.js
+++ b/test/assert/element.test.js
@@ -135,7 +135,7 @@ describe('assert/element', () => {
   describe('#elementIsVisible', () => {
     const element = extend({
       browser: {
-        getElementWithoutError() {
+        getElementOrNull() {
           return { isVisible() { return true; } };
         },
       },
@@ -159,7 +159,7 @@ describe('assert/element', () => {
   describe('#elementNotVisible', () => {
     const element = extend({
       browser: {
-        getElementWithoutError() {
+        getElementOrNull() {
           return { isVisible() { return false; } };
         },
       },
@@ -183,7 +183,7 @@ describe('assert/element', () => {
   describe('#elementExists', () => {
     const element = extend({
       browser: {
-        getElementWithoutError() { return {}; },
+        getElementOrNull() { return {}; },
       },
     }, ElementMixin);
 
@@ -205,7 +205,7 @@ describe('assert/element', () => {
   describe('#elementDoesntExist', () => {
     const element = extend({
       browser: {
-        getElementWithoutError() { return null; },
+        getElementOrNull() { return null; },
       },
     }, ElementMixin);
 


### PR DESCRIPTION
This moves us into the direction of more consistency with `wd`, making it easier to switch back-and-forth. Also can help cleaning up some tests that want to chain method calls onto `getElement` without forcing them to remember the proper null checks.